### PR TITLE
Fixing index out of range issue

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -431,7 +431,7 @@ func worker(jobs <-chan workerJob, results chan<- workerJob, wg *sync.WaitGroup)
 			fmt.Println("URL:", job.startURL)
 			linkOutput := make(map[string]interface{})
 			for _, selector := range job.siteMap.Selectors {
-				if job.parent == selector.ParentSelectors[0] {
+				if len(selector.ParentSelectors)>0 && job.parent == selector.ParentSelectors[0] {
 					if selector.Type == "SelectorText" {
 						resultText := selectorText(doc, &selector)
 						if len(resultText) != 0 {


### PR DESCRIPTION
This PR fixes the below error:
```
goroutine 9 [running]:
main.worker(0xc000121800, 0xc000121860, 0xc000021510)
~/data-scraper/backend.go:434 +0x110f
created by main.scraper
~/data-scraper/backend.go:497 +0x111
exit status 2
```

Although the complete logic for adding the last element should be reviewed and refactored.